### PR TITLE
Error level includes Error() of err

### DIFF
--- a/buflogr.go
+++ b/buflogr.go
@@ -77,7 +77,7 @@ func (l *bufLogger) Info(level int, msg string, kv ...interface{}) {
 // Error implements logr.Logger.Error by prefixing the line with "ERROR" and
 // write it to the internal buffer.
 func (l *bufLogger) Error(err error, msg string, kv ...interface{}) {
-	l.writeLine(LevelError, msg, kv...)
+	l.writeLine(fmt.Sprintf("%s %v", LevelError, err), msg, kv...)
 }
 
 // WithValues returns a new LogSink with additional key/value pairs.

--- a/example/example_test.go
+++ b/example/example_test.go
@@ -41,8 +41,8 @@ func ExampleNew() {
 	// INFO MyName hello module example val1 1 val2 map[k:1]
 	// V[1] MyName you should see this module example
 	// V[2] MyName you will also see this module example
-	// ERROR MyName uh oh module example trouble true reasons [0.1 0.11 3.14]
-	// ERROR MyName goodbye module example code -1
+	// ERROR <nil> MyName uh oh module example trouble true reasons [0.1 0.11 3.14]
+	// ERROR an error occurred MyName goodbye module example code -1
 	// INFO MyName thru a helper module example
 }
 


### PR DESCRIPTION
This changes the output of the .Error() method to include the error
message.

This is a small change to put the actual error from the `.Error()` call into the captured output.